### PR TITLE
true is passed to onLeave when walkthrough is skipped

### DIFF
--- a/src/jquery.pagewalkthrough.js
+++ b/src/jquery.pagewalkthrough.js
@@ -132,7 +132,7 @@
     close: function() {
       var options = _activeWalkthrough;
 
-      onLeave();
+      onLeave(true);
 
       if (typeof options.onClose === 'function') {
         options.onClose.call(this);


### PR DESCRIPTION
Previously the parameter 'e' was undefined always in onLeave() despite whether you had closed the walkthrough or clicked next, by adding true to the function all onLeave(true) denotes that the walkthrough has been cancelled and no further steps should be displayed.